### PR TITLE
Update workflow for release-based deployment

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -8,6 +8,8 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 2 * * *'  # Nightly build at 2 AM UTC
+  release:
+    types: [ published ]
 
 env:
   REGISTRY: ghcr.io
@@ -50,7 +52,7 @@ jobs:
     name: Build and Push Docker Images
     runs-on: ubuntu-latest
     needs: build-and-test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'release' && github.event.action == 'published'
 
     permissions:
       contents: read
@@ -70,57 +72,33 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Extract metadata for API
-      id: meta-api
-      uses: docker/metadata-action@v5
-      with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_API }}
-        tags: |
-          type=ref,event=branch
-          type=ref,event=pr
-          type=sha,prefix={{branch}}-
-          type=raw,value=latest,enable={{is_default_branch}}
-
-    - name: Extract metadata for Web
-      id: meta-web
-      uses: docker/metadata-action@v5
-      with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_WEB }}
-        tags: |
-          type=ref,event=branch
-          type=ref,event=pr
-          type=sha,prefix={{branch}}-
-          type=raw,value=latest,enable={{is_default_branch}}
-
     - name: Build and push API image
       uses: docker/build-push-action@v5
       with:
-        context: .
+        context: ./ParcelTracking.Api
         file: ./ParcelTracking.Api/Dockerfile
         push: true
-        tags: ${{ steps.meta-api.outputs.tags }}
-        labels: ${{ steps.meta-api.outputs.labels }}
+        tags: |
+         ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_API }}:latest
+         ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_API }}:${{ github.event.release.tag_name }}
         platforms: linux/amd64,linux/arm64
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
 
     - name: Build and push Web image
       uses: docker/build-push-action@v5
       with:
-        context: .
+        context: ./ParcelTracking.Web
         file: ./ParcelTracking.Web/Dockerfile
         push: true
-        tags: ${{ steps.meta-web.outputs.tags }}
-        labels: ${{ steps.meta-web.outputs.labels }}
+        tags: |
+         ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_WEB }}:latest
+         ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_WEB }}:${{ github.event.release.tag_name }}
         platforms: linux/amd64,linux/arm64
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
 
   security-scan:
     name: Security Scan
     runs-on: ubuntu-latest
     needs: build-and-push-images
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
     - name: Run Trivy vulnerability scanner for API
@@ -146,7 +124,7 @@ jobs:
     name: Deployment Notification
     runs-on: ubuntu-latest
     needs: [build-and-push-images, security-scan]
-    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: always() && github.event_name == 'release' && github.event.action == 'published'
 
     steps:
     - name: Notify deployment status

--- a/dev.env
+++ b/dev.env
@@ -1,2 +1,0 @@
-POSTGRES_PASSWORD=postgres_dev
-JWT_SECRET_KEY=jwt_dev_$2ju8Uk3


### PR DESCRIPTION
Modified GitHub Actions workflow to trigger on `release` events with the `published` action, replacing the previous `push`-based trigger. Removed `docker/metadata-action` steps and explicitly defined Docker image tags using the release tag name and `latest`. Updated Docker build contexts to point to specific directories and removed build cache usage. Adjusted job conditions for `build-and-push-images`, `security-scan`, and `deployment-notification` to align with the new release-based strategy. Removed sensitive environment variables (`POSTGRES_PASSWORD` and `JWT_SECRET_KEY`) from `dev.env` for improved security.