### PR TITLE
Remove nightly cron & improve image name generation

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,8 +12,8 @@ on:
     types: [ published ]
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME_API: ${{ github.repository }}/api
-  IMAGE_NAME_WEB: ${{ github.repository }}/web
+  IMAGE_NAME_API: ${{ toLower(concat(github.repository, '/api')) }}
+  IMAGE_NAME_WEB: ${{ toLower(concat(github.repository, '/web')) }}
 
 jobs:
   build-and-test:


### PR DESCRIPTION
The nightly build cron schedule at 2 AM UTC was removed, disabling automated nightly builds. Updated `IMAGE_NAME_API` and `IMAGE_NAME_WEB` environment variables to dynamically generate values using `toLower` and `concat` functions. This ensures consistent formatting and improves flexibility by converting repository names to lowercase.