### PR TITLE
Refactor image name construction in build workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,8 +12,8 @@ on:
     types: [ published ]
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME_API: ${{ toLower(concat(github.repository, '/api')) }}
-  IMAGE_NAME_WEB: ${{ toLower(concat(github.repository, '/web')) }}
+  IMAGE_NAME_API: ${{ toLower(format('{0}/api', github.repository)) }}
+  IMAGE_NAME_WEB: ${{ toLower(format('{0}/web', github.repository)) }}
 
 jobs:
   build-and-test:


### PR DESCRIPTION
Replaced the `concat` function with the `format` function for constructing `IMAGE_NAME_API` and `IMAGE_NAME_WEB` in the `build-and-deploy.yml` file. This improves readability and aligns with modern string formatting practices. The cron schedule for the nightly build remains unchanged.