### PR TITLE
Hardcode Docker image names in build-and-deploy.yml

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,8 +12,8 @@ on:
     types: [ published ]
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME_API: ${{ format('{0}/api', github.repository | toLower) }}
-  IMAGE_NAME_WEB: ${{ format('{0}/web', github.repository | toLower) }}
+  IMAGE_NAME_API: simpletrack/api
+  IMAGE_NAME_WEB: simpletrack/web
   
 
 jobs:


### PR DESCRIPTION
Updated the `IMAGE_NAME_API` and `IMAGE_NAME_WEB` environment variables to use hardcoded values (`simpletrack/api` and `simpletrack/web`) instead of dynamically formatting the names based on the repository. This change simplifies the naming process and ensures consistency with a fixed naming convention.